### PR TITLE
Add a basic dashboard display reading from an offline maps table

### DIFF
--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -1,9 +1,104 @@
 <template>
-  <div class="dashboard"></div>
+  <div class="flex flex-col items-center mt-8">
+    <h1 class="text-4xl font-bold text-gray-800 mb-4">Available Offline Maps</h1>
+    <div v-for="item in data" :key="item.id" class="bg-gray-100 rounded-lg p-4 mb-4 w-1/2">
+      <h2 class="text-xl font-semibold text-gray-800 mb-2" v-if="item.filename">{{ item.filename }}</h2>
+      <p class="text-gray-600 mb-1" v-if="item.status">
+        <strong>Status:</strong> 
+        <span :class="formatStatusColor(item.status)">{{ item.status }}</span>
+      </p>
+      <p class="text-gray-600 mb-1" v-if="item.errormessage"><strong>Error Message:</strong> {{ item.errormessage }}</p>
+      <p class="text-gray-600 mb-1" v-if="item.created_at"><strong>Request submitted at:</strong> {{ formatDate(item.created_at) }}</p>
+      <p class="text-gray-600 mb-1" v-if="item.style"><strong>Map style:</strong> {{ item.style }}</p>
+      <p class="text-gray-600 mb-1" v-if="item.bounds"><strong>Bounds:</strong> [{{ formatBounds(item.bounds) }}]</p>
+      <p class="text-gray-600 mb-1" v-if="item.maxzoom"><strong>Zoom level:</strong> {{ item.minzoom }}-{{ item.maxzoom }}</p>
+      <p class="text-gray-600 mb-1" v-if="item.filelocation"><strong>File Location:</strong> <a :href="item.filelocation" class="text-blue-500 hover:text-blue-700">link</a></p>
+      <p class="text-gray-600 mb-1" v-if="item.filesize"><strong>File Size:</strong> {{ formatNumber(item.filesize) }} bytes</p>
+      <p class="text-gray-600 mb-1" v-if="item.numberoftiles"><strong>Number of tiles:</strong> {{ formatNumber(item.numberoftiles) }}</p>
+      <p class="text-gray-600 mb-1" v-if="item.workbegun"><strong>Work begun at:</strong> {{ formatDate(item.workbegun) }}</p>
+      <p class="text-gray-600 mb-1" v-if="item.workended"><strong>Work ended at:</strong> {{ formatDate(item.workended) }}</p>
+
+    </div>
+  </div>
 </template>
 
 <script>
-export default {};
+export default {
+  props: [
+    "data"
+  ],
+  methods: {
+    formatNumber(value) {
+      return parseInt(value).toLocaleString();
+    },
+    formatBounds(bounds) {
+      return bounds.split(',').join(', ');
+    },
+    formatDate(dateString) {
+      const options = { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' };
+      const date = new Date(dateString);
+      return date.toLocaleDateString('en-GB', options).replace(/,/, '');
+    },
+    formatStatusColor(status) {
+      switch (status) {
+        case 'FAILED':
+          return 'font-semibold text-red-500';
+        case 'PENDING':
+          return 'font-semibold text-yellow-500';
+        case 'SUCCEEDED':
+          return 'font-semibold text-green-500';
+        default:
+          return 'font-semibold text-gray-600';
+      }
+    }
+  }
+};
 </script>
 
-<style scoped></style>
+<style scoped>
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 2em;
+}
+
+.container h1 {
+  color: #333;
+  margin-bottom: 1em;
+  font-size: 2em;
+  font-weight: 900;
+}
+
+.table-item {
+  background-color: #f9f9f9;
+  border-radius: 5px;
+  padding: 1em;
+  margin-bottom: 1em;
+  width: 50%;
+}
+
+.table-item h2 {
+  color: #333;
+  margin-bottom: 0.5em;
+}
+
+.table-item ul {
+  list-style: none;
+  padding: 0;
+}
+
+.table-item ul li {
+  margin-bottom: 0.5em;
+}
+
+.table-item ul li a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.table-item ul li a:hover {
+  color: #0056b3;
+  text-decoration: underline;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,10 +1,8 @@
 <template>
-  <div class="container">
-    <h1>Available Offline Maps</h1>
-    <MapDashboard />
-    <div v-for="item in data" :key="item.id" class="table-item">
-      <h2>{{ item }}</h2>
-    </div>
+  <div>
+    <MapDashboard
+      v-if="dataFetched"
+      :data="data" />
   </div>
 </template>
 
@@ -17,11 +15,7 @@ export default {
       title: "MapPacker: Available Offline Maps",
     };
   },
-  data() {
-    return {
-      data: [],
-    };
-  },
+  components: { MapDashboard },
   async asyncData({ $axios, app }) {
     // Set up the headers for the request
     let headers = {
@@ -32,60 +26,17 @@ export default {
     try {
       // Use the table name in the API request
       const response = await $axios.$get(`/api/data`, { headers });
-      return { data: response };
+      return { 
+        dataFetched: true,
+        data: response 
+      };
     } catch (error) {
       // Handle errors as appropriate
       console.error("Error fetching data:", error);
-      return { data: [] };
+      return {
+        dataFetched: false,
+      };    
     }
   },
 };
 </script>
-
-<style scoped>
-.container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 2em;
-}
-
-.container h1 {
-  color: #333;
-  margin-bottom: 1em;
-  font-size: 2em;
-  font-weight: 900;
-}
-
-.table-item {
-  background-color: #f9f9f9;
-  border-radius: 5px;
-  padding: 1em;
-  margin-bottom: 1em;
-  width: 50%;
-}
-
-.table-item h2 {
-  color: #333;
-  margin-bottom: 0.5em;
-}
-
-.table-item ul {
-  list-style: none;
-  padding: 0;
-}
-
-.table-item ul li {
-  margin-bottom: 0.5em;
-}
-
-.table-item ul li a {
-  color: #007bff;
-  text-decoration: none;
-}
-
-.table-item ul li a:hover {
-  color: #0056b3;
-  text-decoration: underline;
-}
-</style>


### PR DESCRIPTION

## Goal

To add a basic dashboard display for offline maps, using currently expected fields from a DB table schema for offline maps.

## Screenshots

![image](https://github.com/ConservationMetrics/mapPacker/assets/31662219/adfe7ff7-15d5-4376-bca7-98ddff257e62)

## What I'm not doing here

As of this time, I'm not worried about styling, user experience, or aesthetics - just trying to get some raw JSON data provided by the web app backend (Express) to look decent.