### PR TITLE
Add `GenerateMap` map and sidebar child components with double-binding state synchronization

### DIFF
--- a/components/GenerateMap.vue
+++ b/components/GenerateMap.vue
@@ -1,18 +1,30 @@
 <template>
   <div>
-    <div id="map"></div>
-    <Sidebar />
+    <Sidebar 
+      @formSubmitted="handleFormSubmit" 
+      @update:params="updateMapParams"
+      :mapboxLatitude="localLatitude" 
+      :mapboxLongitude="localLongitude"
+      :mapboxStyle="mapboxStyle" 
+      :mapboxZoom="localZoom" 
+    />
+    <Map 
+      @update:params="updateMapParams"
+      :mapboxAccessToken="mapboxAccessToken"
+      :mapboxLatitude="localLatitude"
+      :mapboxLongitude="localLongitude"
+      :mapboxStyle="mapboxStyle"
+      :mapboxZoom="localZoom" 
+    />
   </div>
 </template>
 
 <script>
-import mapboxgl from "mapbox-gl";
-import "mapbox-gl/dist/mapbox-gl.css";
-
 import Sidebar from "@/components/Sidebar.vue";
+import Map from "@/components/Map.vue";
 
 export default {
-  components: { Sidebar },
+  components: { Sidebar, Map },
   props: [
     "mapboxAccessToken",
     "mapboxLatitude",
@@ -20,37 +32,22 @@ export default {
     "mapboxStyle",
     "mapboxZoom",
   ],
-  mounted() {
-    mapboxgl.accessToken = this.mapboxAccessToken;
-
-    const map = new mapboxgl.Map({
-      container: "map",
-      style: this.mapboxStyle || "mapbox://styles/mapbox/satellite-streets-v12",
-      projection: "mercator",
-      center: [this.mapboxLongitude || 0, this.mapboxLatitude || -15],
-      zoom: this.mapboxZoom || 2.5,
-    });
-
-    map.on("load", () => {
-      // Navigation Control (zoom buttons and compass)
-      const nav = new mapboxgl.NavigationControl();
-      map.addControl(nav, "top-right");
-
-      // Scale Control
-      const scale = new mapboxgl.ScaleControl({
-        maxWidth: 80,
-        unit: "metric",
-      });
-      map.addControl(scale, "bottom-left");
-
-      // Fullscreen Control
-      const fullscreenControl = new mapboxgl.FullscreenControl();
-      map.addControl(fullscreenControl, "top-right");
-    });
+  data() {
+    return {
+      localLatitude: this.mapboxLatitude,
+      localLongitude: this.mapboxLongitude,
+      localZoom: this.mapboxZoom,
+    };
   },
-  beforeDestroy() {
-    if (this.map) {
-      this.map.remove();
+  methods: {
+    handleFormSubmit(formData) {
+      console.log('Received form data:', formData);
+    },
+    updateMapParams(updateObj) {
+      let { param, value } = updateObj;
+      value = parseFloat(value.toFixed(6));
+
+      this[`local${param}`] = value;
     }
   },
 };
@@ -60,12 +57,5 @@ export default {
 body {
   margin: 0;
   padding: 0;
-}
-
-#map {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 100%;
 }
 </style>

--- a/components/Map.vue
+++ b/components/Map.vue
@@ -1,0 +1,98 @@
+<template>
+    <div id="map"></div>
+</template>
+  
+  <script>
+  import mapboxgl from "mapbox-gl";
+  import "mapbox-gl/dist/mapbox-gl.css";
+  
+  export default {
+    props: [
+      "mapboxAccessToken",
+      "mapboxLatitude",
+      "mapboxLongitude",
+      "mapboxStyle",
+      "mapboxZoom",
+    ],
+    data() {
+      return {
+        map: null,
+        localLatitude: this.mapboxLatitude,
+        localLongitude: this.mapboxLongitude,
+        localZoom: this.mapboxZoom,
+      };
+    },
+    watch: {
+      mapboxLatitude(newVal) {
+        if (this.map) {
+          this.map.setCenter([this.localLongitude, newVal]);
+        }
+      },
+      mapboxLongitude(newVal) {
+        if (this.map) {
+          this.map.setCenter([newVal, this.localLatitude]);
+        }
+      },
+      mapboxZoom(newVal) {
+        if (this.map) {
+          this.map.setZoom(newVal);
+        }
+      },
+    },
+    mounted() {
+      mapboxgl.accessToken = this.mapboxAccessToken;
+  
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: this.mapboxStyle || "mapbox://styles/mapbox/satellite-streets-v12",
+        projection: "mercator",
+        center: [this.mapboxLongitude || 0, this.mapboxLatitude || -15],
+        zoom: this.mapboxZoom || 2.5,
+      });
+      this.map = map;
+  
+      this.map.on("load", () => {
+        // Navigation Control (zoom buttons and compass)
+        const nav = new mapboxgl.NavigationControl();
+        map.addControl(nav, "top-right");
+  
+        // Scale Control
+        const scale = new mapboxgl.ScaleControl({
+          maxWidth: 80,
+          unit: "metric",
+        });
+        map.addControl(scale, "bottom-left");
+  
+        // Track map center and zoom level
+      map.on("moveend", () => {
+        const center = map.getCenter();
+        this.localLatitude = center.lat;
+        this.localLongitude = center.lng;
+        this.$emit('update:params', {param: 'Latitude', value: center.lat});
+        this.$emit('update:params', {param: 'Longitude', value: center.lng});
+      });
+  
+      map.on("zoomend", () => {
+        const zoom = map.getZoom();
+        this.localZoom = zoom;
+        this.$emit('update:params', {param: 'Zoom', value: zoom});
+      });
+      });
+    },
+    beforeDestroy() {
+      if (this.map) {
+        this.map.remove();
+      }
+    },
+  };
+  </script>
+  
+  <style scoped>
+  #map {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+  }
+  </style>
+  

--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -1,28 +1,46 @@
 <template>
-  <div class="mt-4 mx-auto w-full max-w-6xl px-4"> 
-    <nuxt-link to="/map/" class="absolute top-4 right-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer transition-colors duration-200">+ Generate Map</nuxt-link>   
+  <div class="mt-4 mx-auto w-full max-w-6xl px-4">
+    <nuxt-link to="/map/"
+      class="absolute top-4 right-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer transition-colors duration-200">+
+      Generate Map</nuxt-link>
     <h1 class="text-4xl font-bold text-gray-800 mb-8 text-center">Available Offline Maps</h1>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"> 
-      <div v-for="map in data" :key="map.id" class="card bg-white border border-gray-300 rounded-lg shadow-lg p-6 flex flex-col">
-        <h2 class="text-2xl font-bold text-gray-800 mb-4" v-if="map.filename">{{ map.filename }}</h2>
-        <div class="flex justify-between items-center mb-4">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div v-for="map in data" :key="map.id"
+        class="card bg-white border border-gray-300 rounded-lg shadow-lg p-6 flex flex-col">
+        <h2 class="text-2xl font-bold text-gray-800 mb-2" v-if="map.title">{{ map.title }}</h2>
+        <p class="mb-2 italic" v-if="map.description">{{ map.description }}</p>
+        <div v-if="map.filelocation" class="flex mb-2">
+          <a :href="map.filelocation"
+            class="download-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out mr-4">Download</a>
+            <div>
+            <button
+            class="copy-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out"
+            @click="copyLinkToClipboard(map.filelocation, map.id)">Copy Link</button>
+            <div v-if="tooltipId === (map ? map.id : null)"
+            class="tooltip bg-gray-500 text-white py-1 px-2 rounded transition duration-300 ease-in-out">
+            Copied!
+          </div>
+          </div>
+        </div>
+        <div class="space-y-2 flex-grow">
           <p v-if="map.status">
             <span class="font-bold">Status:</span>
             <span :class="formatStatusColor(map.status)">{{ map.status }}</span>
           </p>
-          <a v-if="map.filelocation" :href="map.filelocation" class="download-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out">Download</a>
-        </div>
-        <div class="space-y-2 flex-grow">
           <p class="text-red-600" v-if="map.errormessage">{{ map.errormessage }}</p>
           <p v-if="map.created_at"><span class="font-bold">Requested on:</span> {{ formatDate(map.created_at) }}</p>
-          <p v-if="map.style"><span class="font-bold">Map Style:</span> {{ map.style }}<span v-if="map.planet_monthly_visual"> ({{ map.planet_monthly_visual }})</span><span v-if="map.openstreetmap === true">, with OSM labels </span></p> 
+          <p v-if="map.style"><span class="font-bold">Map Style:</span> {{ map.style }}<span
+              v-if="map.planet_monthly_visual"> ({{ map.planet_monthly_visual }})</span><span
+              v-if="map.openstreetmap === true">, with OSM labels </span></p>
           <p v-if="map.bounds"><span class="font-bold">Bounds:</span> [{{ formatBounds(map.bounds) }}]</p>
           <p v-if="map.maxzoom"><span class="font-bold">Zoom Level:</span> {{ map.minzoom }}-{{ map.maxzoom }}</p>
           <div class="space-y-2 flex-grow" v-if="map.status !== 'PENDING'">
             <h3 class="italic text-lg text-gray-600">Metadata</h3>
-            <p v-if="map.workbegun && map.workended"><span class="font-bold">Task Duration:</span> {{ calculateDuration(map.workbegun, map.workended) }}</p>
+            <p v-if="map.workbegun && map.workended"><span class="font-bold">Task Duration:</span> {{
+              calculateDuration(map.workbegun, map.workended) }}</p>
             <p v-if="map.filesize"><span class="font-bold">File Size:</span> {{ formatNumber(map.filesize) }} bytes</p>
-            <p v-if="map.numberoftiles"><span class="font-bold">Number of Tiles:</span> {{ formatNumber(map.numberoftiles) }}</p>
+            <p v-if="map.numberoftiles"><span class="font-bold">Number of Tiles:</span> {{ formatNumber(map.numberoftiles)
+            }}</p>
           </div>
         </div>
       </div>
@@ -31,10 +49,17 @@
 </template>
 
 <script>
+import { copyLink } from "@/src/utils.ts";
+
 export default {
   props: [
     "data"
   ],
+  data() {
+    return {
+      tooltipId: null
+    };
+  },
   methods: {
     formatNumber(value) {
       return parseInt(value).toLocaleString();
@@ -43,11 +68,11 @@ export default {
       return bounds.split(',').join(', ');
     },
     formatDate(dateString) {
-  const options = { year: 'numeric', month: 'long', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false };
-  const date = new Date(dateString);
-  const formattedDate = date.toLocaleDateString('en-GB', options);
-  return `${formattedDate}`;
-},
+      const options = { year: 'numeric', month: 'long', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false };
+      const date = new Date(dateString);
+      const formattedDate = date.toLocaleDateString('en-GB', options);
+      return `${formattedDate}`;
+    },
     formatStatusColor(status) {
       switch (status) {
         case 'FAILED':
@@ -60,7 +85,7 @@ export default {
           return 'font-semibold text-gray-600';
       }
     },
-      calculateDuration(start, end) {
+    calculateDuration(start, end) {
       const startDate = new Date(start);
       const endDate = new Date(end);
       const duration = endDate - startDate;
@@ -68,7 +93,29 @@ export default {
       const minutes = Math.floor((duration / (1000 * 60)) % 60);
       const seconds = Math.floor((duration / 1000) % 60);
       return `${hours}h ${minutes}m ${seconds}s`;
-    }    
-  }
+    },
+    copyLinkToClipboard(link, id) {
+      copyLink(link)
+        .then(() => {
+           this.tooltipId = id;
+            setTimeout(() => {
+              this.tooltipId = null;
+            }, 1500);
+        })
+        .catch(err => {
+          console.error('Failed to copy:', err);
+        });
+    }
+  },
 };
 </script>
+
+<style scoped>
+.tooltip {
+  position: absolute;
+  margin-left: 10px;
+  white-space: nowrap;
+  transform: translateX(150%) translateY(-110%);
+  z-index: 10;
+}
+</style>

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -1,12 +1,96 @@
 <template>
   <div class="sidebar">
-    <h1>MapPacker: Generate Offline Map</h1>
-    <p><em>Use this tool to send a request to generate an offline map.</em></p>
+    <h1 class="text-xl font-bold text-gray-800 mb-2">MapPacker: Generate Offline Map</h1>
+    <p class="mb-2"><em>Use this tool to send a request to generate an offline map.</em></p>
+    <form @submit.prevent="submitForm">
+      <div class="form-group">
+        <label for="title">Title <span class="text-red-600">*</span></label>
+        <input type="text" id="title" v-model="form.title" required class="input-field" />
+      </div>
+
+      <div class="form-group">
+        <label for="description">Description</label>
+        <textarea id="description" v-model="form.description" class="input-field"></textarea>
+      </div>
+
+      <div class="form-group">
+        <label>Zoom Level (0 - 22) <span class="text-red-600">*</span></label>
+        <vue-slider v-model="form.localZoom" :min="0" :max="22" :dot-size="14" :tooltip="'always'" :height="6"
+          class="slider"></vue-slider>
+      </div>
+
+      <div class="form-group flex">
+        <div class="flex-grow mr-2">
+          <label for="centerLat">Center Latitude</label>
+          <input type="number" step="0.000001" id="localLatitude" v-model.number="form.localLatitude" required :min="-90"
+            :max="90" class="input-field" />
+        </div>
+        <div class="flex-grow">
+          <label for="centerLng">Center Longitude</label>
+          <input type="number" step="0.000001" id="localLongitude" v-model.number="form.localLongitude" required :min="-180"
+            :max="180" class="input-field" />
+        </div>
+      </div>
+
+      <button type="submit" class="submit-button">Submit Request</button>
+    </form>
   </div>
 </template>
 
 <script>
-export default {};
+import VueSlider from 'vue-slider-component';
+import "vue-slider-component/dist-css/vue-slider-component.css";
+import "vue-slider-component/theme/default.css";
+
+export default {
+  components: { VueSlider },
+  props: [
+    "mapboxAccessToken",
+    "mapboxLatitude",
+    "mapboxLongitude",
+    "mapboxStyle",
+    "mapboxZoom",
+  ],
+  data() {
+    return {
+      form: {
+        title: '',
+        description: '',
+        localZoom: this.mapboxZoom,
+        localLatitude: this.mapboxLatitude,
+        localLongitude: this.mapboxLongitude,
+      },
+    };
+  },
+  watch: {
+    mapboxLatitude(newVal) {
+      this.form.localLatitude = newVal;
+    },
+    mapboxLongitude(newVal) {
+      this.form.localLongitude = newVal;
+    },
+    mapboxZoom(newVal) {
+      this.form.localZoom = newVal;
+    },
+    'form.localZoom': {
+      handler(newVal) {
+        this.$emit('update:params', {param: 'Zoom', value: newVal});
+      },
+      deep: true
+    },
+    'form.localLatitude': function (newVal) {
+      this.$emit('update:params', {param: 'Latitude', value: newVal});
+    },
+    'form.localLongitude': function (newVal) {
+      this.$emit('update:params', {param: 'Longitude', value: newVal});
+    }
+  },
+  methods: {
+    submitForm() {
+      this.$emit('formSubmitted', this.form);
+    }
+  },
+};
 </script>
 
 <style scoped>
@@ -30,5 +114,68 @@ export default {};
     bottom: 0;
     top: auto;
   }
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group.flex {
+  display: flex;
+}
+
+.input-field {
+  flex-grow: 1;
+  /* Ensure inputs take up available space */
+}
+
+.flex-grow {
+  flex: 1;
+  /* Allow children to grow to fill space */
+}
+
+.flex-grow.mr-2 {
+  margin-right: 0.5rem;
+  /* Add some spacing between the latitude and longitude fields */
+}
+
+.input-field {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  margin-top: 6px;
+}
+
+.slider-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+.slider {
+  width: calc(50% - 8px);
+  margin: 10px 0;
+}
+
+.inline-fields>div {
+  display: inline-block;
+  width: calc(50% - 10px);
+  margin-right: 10px;
+}
+
+.submit-button {
+  background-color: #4CAF50;
+  color: white;
+  padding: 14px 20px;
+  margin: 10px 0;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+}
+
+.submit-button:hover {
+  background-color: #45a049;
 }
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "pg": "^8.11.3",
         "vue": "^2.7.10",
         "vue-server-renderer": "^2.7.10",
+        "vue-slider-component": "^3.2.24",
         "vue-template-compiler": "^2.7.10"
       },
       "devDependencies": {
@@ -35,6 +36,9 @@
         "nuxt-windicss": "^2",
         "prettier": "^3.2.5",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": "18.17.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -18647,6 +18651,14 @@
         "csstype": "^3.1.0"
       }
     },
+    "node_modules/vue-class-component": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
+      "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
+      }
+    },
     "node_modules/vue-client-only": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/vue-client-only/-/vue-client-only-2.1.0.tgz",
@@ -18726,6 +18738,17 @@
       "resolved": "https://registry.npmjs.org/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz",
       "integrity": "sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g=="
     },
+    "node_modules/vue-property-decorator": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz",
+      "integrity": "sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==",
+      "dependencies": {
+        "vue-class-component": "^7.1.0"
+      },
+      "peerDependencies": {
+        "vue": "*"
+      }
+    },
     "node_modules/vue-router": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
@@ -18752,6 +18775,15 @@
       "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vue-slider-component": {
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/vue-slider-component/-/vue-slider-component-3.2.24.tgz",
+      "integrity": "sha512-28hfotAL/CPXPwqHgVFyUwUEV0zweoc2wW0bgraGkoIcRZGlFjk8caYJLE8+Luug5t3b9tJm/NyDXpyIdmcYZg==",
+      "dependencies": {
+        "core-js": "^3.6.5",
+        "vue-property-decorator": "^8.0.0"
       }
     },
     "node_modules/vue-style-loader": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pg": "^8.11.3",
     "vue": "^2.7.10",
     "vue-server-renderer": "^2.7.10",
+    "vue-slider-component": "^3.2.24",
     "vue-template-compiler": "^2.7.10"
   },
   "devDependencies": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,27 @@
+export function copyLink(link: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (navigator.clipboard) {
+      navigator.clipboard
+        .writeText(link)
+        .then(() => {
+          resolve();
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    } else {
+      const textArea = document.createElement("textarea");
+      textArea.value = link;
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      try {
+        document.execCommand("copy");
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+      document.body.removeChild(textArea);
+    }
+  });
+}


### PR DESCRIPTION
## Goal

To split up the `GenerateMap` view into a parent and two new child components (`Map` and `Sidebar`), and to add double-binding functionality and smooth state synchronization between them.

## Screenshots

![image](https://github.com/ConservationMetrics/mapPacker/assets/31662219/ef3c9ed2-5be4-4044-b90e-53315e89ffce)

## What I changed

* Created a new component `Map.vue` and moved all MapGL related code there.
* Stored and handled the map as a Reactive Vue state object.
* Substantially expanded the Sidebar component:
  * Added Title, Description, Zoom, and Latitude + Longitude fields.
  * Implemented `vue-slider-component` for the Zoom field to set maxZoom.
* Both Sidebar and Map child components listen for changes (to the fields in Sidebar or the Map canvas, respectively) and emit them back to the parent component.
* Upon receiving these changes, GenerateMap uses an updateMapParams function to pass the updated values (rounded to a reasonable number of decimal places) to the child components.
* Oops, some stylistic changes out-of-scope for this PR were made to the `MapDashboard`, including functionality to copy an offline map link and display a popup notification that the link has been copied.

## What I'm not doing here

To get this working, I needed to store the map as a reactive state, which [breaks the map rendering](https://github.com/mapbox/mapbox-gl-js/issues/6872); a known bug with Mapbox + Vue with some documented workarounds. I will fix this in follow-up work.