### PR TITLE
Refactor `GenerateMap` panel into separate components per concern; add request submitted modal

### DIFF
--- a/components/GenerateMap.vue
+++ b/components/GenerateMap.vue
@@ -1,14 +1,17 @@
 <template>
   <div>
-    <Panels
+    <Sidebar
       @formSubmitted="handleFormSubmit"
       @updateMapParams="updateMapParams"
       :availableMapStyles="availableMapStyles"
       :customMapboxStyle="customMapboxStyle"
       :mapBounds="selectedBounds"
+      :mapStyle="selectedStyle"
+    />
+    <MapNavigation
+      @updateMapParams="updateMapParams"
       :mapLatitude="selectedLatitude"
       :mapLongitude="selectedLongitude"
-      :mapStyle="selectedStyle"
       :mapZoom="selectedZoom"
     />
     <Map
@@ -19,15 +22,21 @@
       :mapStyle="selectedStyle"
       :mapZoom="selectedZoom"
     />
+    <div v-if="showModal" class="overlay"></div>
+    <div v-if="showModal" class="modal">
+      Offline map request successfully submitted!
+    </div>
   </div>
 </template>
 
 <script>
-import Panels from "@/components/GenerateMap/Panels.vue";
+import Sidebar from "@/components/GenerateMap/Sidebar.vue";
+import MapNavigation from "@/components/GenerateMap/MapNavigation.vue";
 import Map from "@/components/GenerateMap/Map.vue";
 
+
 export default {
-  components: { Panels, Map },
+  components: { Map, Sidebar, MapNavigation },
   props: [
     "availableMapStyles",
     "customMapboxStyle",
@@ -43,13 +52,17 @@ export default {
       selectedLongitude: this.mapLongitude,
       selectedStyle: this.customMapboxStyle,
       selectedZoom: this.mapZoom,
+      showModal: false,
     };
   },
   methods: {
     handleFormSubmit(formData) {
       // TODO: Send as a POST request to the API
-      // TODO: Add modal to show success and redirect to MapDashboard
       console.log("Received form data:", formData);
+      this.showModal = true; //
+      setTimeout(() => {
+        this.$router.push('/');
+      }, 3000);
     },
     updateMapParams(updateObj) {
       let { param, value } = updateObj;
@@ -64,9 +77,165 @@ export default {
 };
 </script>
 
+<!-- CSS rules applying across parent and child components -->
 <style scoped>
 body {
   margin: 0;
   padding: 0;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 400px;
+  background: white;
+  padding: 20px;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.map-navigation {
+  position: fixed;
+  bottom: 30px;
+  right: 10px;
+  width: 250px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 10px;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+  overflow-y: none;
+  z-index: 1000;
+  border-radius: 6px;
+
+  .input-field {
+    padding: 5px !important;
+  }
+
+  .form-group {
+    margin-bottom: 0px;
+  }
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    height: 50%;
+    width: 100%;
+    bottom: 0;
+    top: auto;
+  }
+
+  .map-navigation {
+    display: none;
+  }
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group.flex {
+  display: flex;
+}
+
+.input-field {
+  flex-grow: 1;
+}
+
+.flex-grow {
+  flex: 1;
+}
+
+.flex-grow.mr-2 {
+  margin-right: 0.5rem;
+}
+
+.input-field {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  margin-top: 6px;
+}
+
+.osm-checkbox {
+  width: 20px !important;
+  margin: 0;
+  flex-grow: 0;
+}
+
+.slider-container {
+  display: flex;
+  justify-content: space-between;
+}
+
+.slider {
+  width: calc(50% - 8px);
+  margin: 10px 0;
+}
+
+.inline-fields > div {
+  display: inline-block;
+  width: calc(50% - 10px);
+  margin-right: 10px;
+}
+
+.code-block {
+  width: 100%;
+  padding: 12px 20px;
+  box-sizing: border-box;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: monospace;
+  resize: none;
+  overflow: auto;
+  min-height: 50px;
+  line-height: 1.5;
+}
+
+.submit-button {
+  background-color: #4caf50;
+  color: white;
+  padding: 14px 20px;
+  margin: 10px 0;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  width: 100%;
+}
+
+.submit-button:hover {
+  background-color: #45a049;
+}
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 1040;
+}
+
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 20px;
+  z-index: 1050;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0,0,0,.1);
+  text-align: center;
+  animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 </style>

--- a/components/GenerateMap.vue
+++ b/components/GenerateMap.vue
@@ -33,7 +33,7 @@
 import Sidebar from "@/components/GenerateMap/Sidebar.vue";
 import MapNavigation from "@/components/GenerateMap/MapNavigation.vue";
 import Map from "@/components/GenerateMap/Map.vue";
-
+import style from '@/components/GenerateMap/style.css';
 
 export default {
   components: { Map, Sidebar, MapNavigation },
@@ -74,168 +74,17 @@ export default {
       this[`selected${param}`] = value;
     },
   },
+  computed: {
+    style() {
+      return style;
+    },
+  }
 };
 </script>
 
-<!-- CSS rules applying across parent and child components -->
 <style scoped>
 body {
   margin: 0;
   padding: 0;
-}
-
-.sidebar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 400px;
-  background: white;
-  padding: 20px;
-  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
-  overflow-y: auto;
-  z-index: 1000;
-}
-
-.map-navigation {
-  position: fixed;
-  bottom: 30px;
-  right: 10px;
-  width: 250px;
-  background: rgba(255, 255, 255, 0.8);
-  padding: 10px;
-  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
-  overflow-y: none;
-  z-index: 1000;
-  border-radius: 6px;
-
-  .input-field {
-    padding: 5px !important;
-  }
-
-  .form-group {
-    margin-bottom: 0px;
-  }
-}
-
-@media (max-width: 768px) {
-  .sidebar {
-    height: 50%;
-    width: 100%;
-    bottom: 0;
-    top: auto;
-  }
-
-  .map-navigation {
-    display: none;
-  }
-}
-
-.form-group {
-  margin-bottom: 20px;
-}
-
-.form-group.flex {
-  display: flex;
-}
-
-.input-field {
-  flex-grow: 1;
-}
-
-.flex-grow {
-  flex: 1;
-}
-
-.flex-grow.mr-2 {
-  margin-right: 0.5rem;
-}
-
-.input-field {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  box-sizing: border-box;
-  margin-top: 6px;
-}
-
-.osm-checkbox {
-  width: 20px !important;
-  margin: 0;
-  flex-grow: 0;
-}
-
-.slider-container {
-  display: flex;
-  justify-content: space-between;
-}
-
-.slider {
-  width: calc(50% - 8px);
-  margin: 10px 0;
-}
-
-.inline-fields > div {
-  display: inline-block;
-  width: calc(50% - 10px);
-  margin-right: 10px;
-}
-
-.code-block {
-  width: 100%;
-  padding: 12px 20px;
-  box-sizing: border-box;
-  background-color: #f5f5f5;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-family: monospace;
-  resize: none;
-  overflow: auto;
-  min-height: 50px;
-  line-height: 1.5;
-}
-
-.submit-button {
-  background-color: #4caf50;
-  color: white;
-  padding: 14px 20px;
-  margin: 10px 0;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  width: 100%;
-}
-
-.submit-button:hover {
-  background-color: #45a049;
-}
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.75);
-  z-index: 1040;
-}
-
-.modal {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: white;
-  padding: 20px;
-  z-index: 1050;
-  border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0,0,0,.1);
-  text-align: center;
-  animation: fadeIn 0.5s ease;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
 }
 </style>

--- a/components/GenerateMap/MapNavigation.vue
+++ b/components/GenerateMap/MapNavigation.vue
@@ -1,0 +1,72 @@
+<template>
+    <div class="map-navigation">
+        <h2 class="text-xl font-bold text-gray-800 mb-2">Map controls</h2>
+        <div class="form-group">
+            <label>Zoom level (0 - 16) <span class="text-red-600">*</span></label>
+            <vue-slider v-model="form.selectedZoom" :min="0" :max="16" :dot-size="14" :tooltip="'always'" :height="6"
+                class="slider"></vue-slider>
+        </div>
+
+        <div class="form-group flex">
+            <div class="flex-grow mr-2">
+                <label for="centerLat">Center lat</label>
+                <input type="number" step="0.000001" id="selectedLatitude" v-model.number="form.selectedLatitude" required
+                    :min="-90" :max="90" class="input-field" />
+            </div>
+            <div class="flex-grow">
+                <label for="centerLng">Center long</label>
+                <input type="number" step="0.000001" id="selectedLongitude" v-model.number="form.selectedLongitude" required
+                    :min="-180" :max="180" class="input-field" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import VueSlider from "vue-slider-component";
+
+export default {
+  components: { VueSlider },
+  props: [
+    "mapLatitude",
+    "mapLongitude",
+    "mapZoom",
+  ],
+  data() {
+    return {
+      form: {
+        selectedLatitude: this.mapLatitude,
+        selectedLongitude: this.mapLongitude,
+        selectedZoom: this.mapZoom,
+      },
+    };
+  },
+  watch: {
+    // Watch for changes to the map's latitude, longitude, and zoom
+    mapLatitude(newVal) {
+      this.form.selectedLatitude = newVal;
+    },
+    mapLongitude(newVal) {
+      this.form.selectedLongitude = newVal;
+    },
+    mapZoom(newVal) {
+      this.form.selectedZoom = newVal;
+    },
+
+    // Track and emit changes to map parameters in the sidebar form,
+    // So that the parent component can update the map
+    "form.selectedLatitude": function (newVal) {
+      this.$emit("updateMapParams", { param: "Latitude", value: newVal });
+    },
+    "form.selectedLongitude": function (newVal) {
+      this.$emit("updateMapParams", { param: "Longitude", value: newVal });
+    },
+    "form.selectedZoom": {
+      handler(newVal) {
+        this.$emit("updateMapParams", { param: "Zoom", value: newVal });
+      },
+      deep: true,
+    },
+  },
+};
+</script>

--- a/components/GenerateMap/Sidebar.vue
+++ b/components/GenerateMap/Sidebar.vue
@@ -108,10 +108,17 @@
         <!-- Show estimated number of tiles -->
         <!-- Note that filesize of each tile varies and it's quite tricky to correctly approximate -->
         <!-- See https://github.com/mapbox/mapbox-gl-native/issues/4258 -->
-        <p v-if="form.maxZoom && form.selectedBounds" class="italic">
+        <div v-if="form.maxZoom && form.selectedBounds">
+        <p class="italic">
           Estimated number of tiles:
-          {{ estimateNumberOfTiles(form.maxZoom, form.selectedBounds) }}
+          {{ estimatedTiles.toLocaleString() }}
         </p>
+        <p v-if="estimatedTiles > 100000" class="text-red-600 mt-2">
+          <span class="font-bold">Warning:</span> You are requesting over 100,000 tiles.
+          Note that this will generate a very large offline map file.
+          Please also make sure you will not exceed your tile quota for the map style API, or run into unexpected costs.
+        </p>
+        </div>
 
         <button type="submit" class="submit-button">Submit Request</button>
       </form>
@@ -256,6 +263,9 @@ export default {
     maxPlanetMonthYear() {
       return calculatePlanetMonthYear();
     },
+    estimatedTiles() {
+      return this.estimateNumberOfTiles(this.form.maxZoom, this.form.selectedBounds);
+    }
   },
   mounted() {
     this.fetchMapStyles();

--- a/components/GenerateMap/Sidebar.vue
+++ b/components/GenerateMap/Sidebar.vue
@@ -1,11 +1,10 @@
 <template>
-  <div>
-    <div class="sidebar">
+  <div class="sidebar">
       <h1 class="text-xl font-bold text-gray-800 mb-2">
         MapPacker: Generate Offline Map
       </h1>
       <p class="mb-2">
-        <em>Use this tool to send a request to generate an offline map.</em>
+        <em>Use this interface to submit a request to generate an offline map.</em>
       </p>
       <form @submit.prevent="submitForm">
         <div class="form-group">
@@ -29,7 +28,7 @@
         </div>
 
         <div class="form-group">
-          <label for="mapStyle">Map Style</label>
+          <label for="mapStyle">Map Style <span class="text-red-600">*</span></label>
           <select
             id="mapStyle"
             v-model="form.selectedStyle"
@@ -95,13 +94,14 @@
         </div>
 
         <div class="form-group">
-          <label for="bbox">Offline Map Bounding Box (draw on map)</label>
+          <label for="bbox">Offline Map Bounding Box (draw on map) <span class="text-red-600">*</span></label>
           <textarea
             type="text"
             v-model="form.selectedBounds"
             id="bbox"
-            disabled
+            required
             class="code-block"
+            @keydown.prevent
           />
         </div>
 
@@ -115,51 +115,7 @@
 
         <button type="submit" class="submit-button">Submit Request</button>
       </form>
-    </div>
-    <div class="map-navigation">
-      <h2 class="text-xl font-bold text-gray-800 mb-2">Map controls</h2>
-      <div class="form-group">
-        <label>Zoom level (0 - 16) <span class="text-red-600">*</span></label>
-        <vue-slider
-          v-model="form.selectedZoom"
-          :min="0"
-          :max="16"
-          :dot-size="14"
-          :tooltip="'always'"
-          :height="6"
-          class="slider"
-        ></vue-slider>
-      </div>
 
-      <div class="form-group flex">
-        <div class="flex-grow mr-2">
-          <label for="centerLat">Center lat</label>
-          <input
-            type="number"
-            step="0.000001"
-            id="selectedLatitude"
-            v-model.number="form.selectedLatitude"
-            required
-            :min="-90"
-            :max="90"
-            class="input-field"
-          />
-        </div>
-        <div class="flex-grow">
-          <label for="centerLng">Center long</label>
-          <input
-            type="number"
-            step="0.000001"
-            id="selectedLongitude"
-            v-model.number="form.selectedLongitude"
-            required
-            :min="-180"
-            :max="180"
-            class="input-field"
-          />
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -177,10 +133,7 @@ export default {
     "customMapboxStyle",
     "mapboxAccessToken",
     "mapBounds",
-    "mapLatitude",
-    "mapLongitude",
     "mapStyle",
-    "mapZoom",
   ],
   data() {
     return {
@@ -199,49 +152,25 @@ export default {
         title: "",
         description: "",
         selectedBounds: this.mapBounds,
-        selectedLatitude: this.mapLatitude,
-        selectedLongitude: this.mapLongitude,
         selectedStyle: this.customMapboxStyle,
-        selectedZoom: this.mapZoom,
         planetMonthYear: calculatePlanetMonthYear(),
         maxZoom: 8,
       },
     };
   },
   watch: {
-    // Watch for changes to the map's latitude, longitude, zoom, and style props
+    // Watch for changes to the map's style and bounds props
     mapBounds(newVal) {
       this.form.selectedBounds = newVal;
-    },
-    mapLatitude(newVal) {
-      this.form.selectedLatitude = newVal;
-    },
-    mapLongitude(newVal) {
-      this.form.selectedLongitude = newVal;
     },
     mapStyle(newVal) {
       this.form.selectedStyle = newVal;
     },
-    mapZoom(newVal) {
-      this.form.selectedZoom = newVal;
-    },
 
     // Track and emit changes to map parameters in the sidebar form,
     // So that the parent component can update the map
-    "form.selectedLatitude": function (newVal) {
-      this.$emit("updateMapParams", { param: "Latitude", value: newVal });
-    },
-    "form.selectedLongitude": function (newVal) {
-      this.$emit("updateMapParams", { param: "Longitude", value: newVal });
-    },
     "form.selectedStyle": function (newVal) {
       this.$emit("updateMapParams", { param: "Style", value: newVal });
-    },
-    "form.selectedZoom": {
-      handler(newVal) {
-        this.$emit("updateMapParams", { param: "Zoom", value: newVal });
-      },
-      deep: true,
     },
     "form.planetMonthYear": function (newVal) {
       if (this.form.selectedStyle.includes("/api/mapstyle/planet/")) {
@@ -333,132 +262,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-.sidebar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 400px;
-  background: white;
-  padding: 20px;
-  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
-  overflow-y: auto;
-  z-index: 1000;
-}
-
-.map-navigation {
-  position: fixed;
-  bottom: 30px;
-  right: 10px;
-  width: 250px;
-  background: rgba(255, 255, 255, 0.8);
-  padding: 10px;
-  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
-  overflow-y: none;
-  z-index: 1000;
-  border-radius: 6px;
-
-  .input-field {
-    padding: 5px !important;
-  }
-
-  .form-group {
-    margin-bottom: 0px;
-  }
-}
-
-@media (max-width: 768px) {
-  .sidebar {
-    height: 50%;
-    width: 100%;
-    bottom: 0;
-    top: auto;
-  }
-
-  .map-navigation {
-    display: none;
-  }
-}
-
-.form-group {
-  margin-bottom: 20px;
-}
-
-.form-group.flex {
-  display: flex;
-}
-
-.input-field {
-  flex-grow: 1;
-}
-
-.flex-grow {
-  flex: 1;
-}
-
-.flex-grow.mr-2 {
-  margin-right: 0.5rem;
-}
-
-.input-field {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  box-sizing: border-box;
-  margin-top: 6px;
-}
-
-.osm-checkbox {
-  width: 20px !important;
-  margin: 0;
-  flex-grow: 0;
-}
-
-.slider-container {
-  display: flex;
-  justify-content: space-between;
-}
-
-.slider {
-  width: calc(50% - 8px);
-  margin: 10px 0;
-}
-
-.inline-fields > div {
-  display: inline-block;
-  width: calc(50% - 10px);
-  margin-right: 10px;
-}
-
-.code-block {
-  width: 100%;
-  padding: 12px 20px;
-  box-sizing: border-box;
-  background-color: #f5f5f5;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-family: monospace;
-  resize: none;
-  overflow: auto;
-  min-height: 50px;
-  line-height: 1.5;
-}
-
-.submit-button {
-  background-color: #4caf50;
-  color: white;
-  padding: 14px 20px;
-  margin: 10px 0;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  width: 100%;
-}
-
-.submit-button:hover {
-  background-color: #45a049;
-}
-</style>

--- a/components/GenerateMap/style.css
+++ b/components/GenerateMap/style.css
@@ -1,0 +1,157 @@
+
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 400px;
+    background: white;
+    padding: 20px;
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+    overflow-y: auto;
+    z-index: 1000;
+  }
+  
+  .map-navigation {
+    position: fixed;
+    bottom: 30px;
+    right: 10px;
+    width: 250px;
+    background: rgba(255, 255, 255, 0.8);
+    padding: 10px;
+    box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+    overflow-y: none;
+    z-index: 1000;
+    border-radius: 6px;
+  
+    .input-field {
+      padding: 5px !important;
+    }
+  
+    .form-group {
+      margin-bottom: 0px;
+    }
+  }
+  
+  @media (max-width: 768px) {
+    .sidebar {
+      height: 50%;
+      width: 100%;
+      bottom: 0;
+      top: auto;
+    }
+  
+    .map-navigation {
+      display: none;
+    }
+  }
+  
+  .form-group {
+    margin-bottom: 20px;
+  }
+  
+  .form-group.flex {
+    display: flex;
+  }
+  
+  .input-field {
+    flex-grow: 1;
+  }
+  
+  .flex-grow {
+    flex: 1;
+  }
+  
+  .flex-grow.mr-2 {
+    margin-right: 0.5rem;
+  }
+  
+  .input-field {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+    margin-top: 6px;
+  }
+  
+  .osm-checkbox {
+    width: 20px !important;
+    margin: 0;
+    flex-grow: 0;
+  }
+  
+  .slider-container {
+    display: flex;
+    justify-content: space-between;
+  }
+  
+  .slider {
+    width: calc(50% - 8px);
+    margin: 10px 0;
+  }
+  
+  .inline-fields > div {
+    display: inline-block;
+    width: calc(50% - 10px);
+    margin-right: 10px;
+  }
+  
+  .code-block {
+    width: 100%;
+    padding: 12px 20px;
+    box-sizing: border-box;
+    background-color: #f5f5f5;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: monospace;
+    resize: none;
+    overflow: auto;
+    min-height: 50px;
+    line-height: 1.5;
+  }
+  
+  .submit-button {
+    background-color: #4caf50;
+    color: white;
+    padding: 14px 20px;
+    margin: 10px 0;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    width: 100%;
+  }
+  
+  .submit-button:hover {
+    background-color: #45a049;
+  }
+  
+  /* Request successfully submitted modal */
+  .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.75);
+    z-index: 1040;
+  }
+  
+  .modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    padding: 20px;
+    z-index: 1050;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0,0,0,.1);
+    text-align: center;
+    animation: fadeIn 0.5s ease;
+  }
+  
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }


### PR DESCRIPTION
By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.

## Goal

The goal of this PR is two-fold:
1. Tidy up the code by splitting up Panels into two separate components `MapNavigation` and `Sidebar` with a shared css file.
2. Finish a few loose ends for the sidebar by adding a "request submitted" modal and redirect logic, as well as a warning about large tilesize.

## Screenshots

![image](https://github.com/ConservationMetrics/mapPacker/assets/31662219/c91eb693-8b6f-4de1-ac18-e62fa097c884)
![image](https://github.com/ConservationMetrics/mapPacker/assets/31662219/65cd7700-bf23-4d0f-a54b-ae88bba7652c)

## What I changed

* Split up Panels into two separate components `MapNavigation` and `Sidebar` with a shared css file.
* Added a modal showing a message "Offline map request successfully submitted" for 3 seconds, before redirecting back to the `MapDashboard`.
* In addition to showing an estimated number of tiles, if that number exceeds 100,000, added a warning message about the potential filesize and API implications of that request.